### PR TITLE
Artificial Viscosity

### DIFF
--- a/src/defaultparams.py
+++ b/src/defaultparams.py
@@ -89,6 +89,12 @@ Numerics = {
 		# Default is set to 100.
 		# This parameter modifies the sensitivity of the MinMod shock
 		# indicator. It is problem dependent.
+	"ArtificialViscosity" : False,
+		# Flag to use artificial viscosity
+		# If true, artificial visocity will be added
+	"AVParameter" : 1.,
+		# Parameter in the artificial viscosity term. A larger value will
+		# increase the amount of AV added, giving a smoother solution.
 	"SourceTreatmentADER" : "Explicit",
 		# Treatment of source terms for ADER-DG
 		# Either "Explicit" or "Implicit"

--- a/src/numerics/basis/tools.py
+++ b/src/numerics/basis/tools.py
@@ -233,29 +233,6 @@ def get_elem_mass_matrix(mesh, basis, order, elem_ID=-1,
 
 	return MM # [nb, nb]
 
-def get_poisson_stiffness_matrices(basis_phys_grad_elems, quad_wts, djac_elems):
-	'''
-	Calculate the stiffness matrices of a Poisson-like term for all elements.
-	This is the integral of the gradient of the basis functions dotted with
-	itself (where the dot product is across dimensions). The computation is
-	performed in physical space.
-
-	Inputs:
-	-------
-		basis_phys_grad_elems: gradient in physical space of the basis values
-			for each element
-		quad_wts: quadrature rule weights
-		djac_elems: determinant of the Jacobian of physical space with respect
-			to reference space
-
-	Outputs:
-	--------
-		SM_all: all stiffness matrices
-	'''
-	# Calculate the stiffness matrices in physical space
-	return np.einsum('ijpm, ijnm, jx, ijx -> ipn', basis_phys_grad_elems,
-			basis_phys_grad_elems, quad_wts, djac_elems)
-
 def get_stiffness_matrix(solver, mesh, order, elem_ID):
 	'''
 	Calculate the stiffness matrix

--- a/src/numerics/basis/tools.py
+++ b/src/numerics/basis/tools.py
@@ -121,8 +121,8 @@ def gauss_lobatto_nodes_1D_range(start, stop, nnodes):
 	if stop <= start:
 		raise ValueError
 
-	# Note: This function can ONLY get the points on the 
-	# reference segment therefore start and stop are 
+	# Note: This function can ONLY get the points on the
+	# reference segment therefore start and stop are
 	# ALWAYS constrained to -1 and 1.
 	if start != -1.:
 		raise ValueError
@@ -232,6 +232,39 @@ def get_elem_mass_matrix(mesh, basis, order, elem_ID=-1,
 	MM = np.matmul(basis_val.transpose(), basis_val*quad_wts*djac) # [nb, nb]
 
 	return MM # [nb, nb]
+
+def get_poisson_stiffness_matrices(basis_phys_grad_elems, quad_wts, djac_elems):
+	'''
+	Calculate the stiffness matrices of a Poisson-like term for all elements.
+	This is the integral of the gradient of the basis functions dotted with
+	itself (where the dot product is across dimensions). The computation is
+	performed in physical space.
+
+	Inputs:
+	-------
+		basis_phys_grad_elems: gradient in physical space of the basis values
+			for each element
+		quad_wts: quadrature rule weights
+		djac_elems: determinant of the Jacobian of physical space with respect
+			to reference space
+
+	Outputs:
+	--------
+		SM_all: all stiffness matrices
+	'''
+	num_elems = basis_phys_grad_elems.shape[0]
+	nb = basis_phys_grad_elems.shape[2]
+
+	SM_all = np.zeros([num_elems, nb, nb])
+
+	for elem_ID in range(num_elems):
+		# Calculate the stiffness matrix in physical space
+		SM = np.einsum('jpm, jnm, jx, jx -> pn', basis_phys_grad_elems[elem_ID],
+				basis_phys_grad_elems[elem_ID], quad_wts, djac_elems[elem_ID])
+		# Store
+		SM_all[elem_ID] = SM
+
+	return SM_all # [num_elems, nb, nb]
 
 
 def get_stiffness_matrix(solver, mesh, order, elem_ID):
@@ -520,7 +553,7 @@ def get_lagrange_basis_3D(xq, xnodes, basis_val=None, basis_ref_grad=None):
 	# Tensor products to get 3D basis values
 	if basis_val is not None:
 		for i in range(xq.shape[0]):
-			basis_val[i, :] = np.reshape(np.outer(np.outer(valx[i, :], 
+			basis_val[i, :] = np.reshape(np.outer(np.outer(valx[i, :],
 					valy[i, :]), valz[i, :]), (-1, ), 'F')
 	if basis_ref_grad is not None:
 		for i in range(xq.shape[0]):

--- a/src/numerics/basis/tools.py
+++ b/src/numerics/basis/tools.py
@@ -252,20 +252,9 @@ def get_poisson_stiffness_matrices(basis_phys_grad_elems, quad_wts, djac_elems):
 	--------
 		SM_all: all stiffness matrices
 	'''
-	num_elems = basis_phys_grad_elems.shape[0]
-	nb = basis_phys_grad_elems.shape[2]
-
-	SM_all = np.zeros([num_elems, nb, nb])
-
-	for elem_ID in range(num_elems):
-		# Calculate the stiffness matrix in physical space
-		SM = np.einsum('jpm, jnm, jx, jx -> pn', basis_phys_grad_elems[elem_ID],
-				basis_phys_grad_elems[elem_ID], quad_wts, djac_elems[elem_ID])
-		# Store
-		SM_all[elem_ID] = SM
-
-	return SM_all # [num_elems, nb, nb]
-
+	# Calculate the stiffness matrices in physical space
+	return np.einsum('ijpm, ijnm, jx, ijx -> ipn', basis_phys_grad_elems,
+			basis_phys_grad_elems, quad_wts, djac_elems)
 
 def get_stiffness_matrix(solver, mesh, order, elem_ID):
 	'''

--- a/src/physics/euler/euler.py
+++ b/src/physics/euler/euler.py
@@ -137,11 +137,45 @@ class Euler(base.PhysicsBase):
 			varq = np.linalg.norm(mom, axis=2, keepdims=True)/rho + np.sqrt(
 					gamma*get_pressure()/rho)
 		elif vname is self.AdditionalVariables["Velocity"].name:
-			varq = np.linalg.norm(mom, axis=2, keepdims=True)/rho 
+			varq = np.linalg.norm(mom, axis=2, keepdims=True)/rho
 		else:
 			raise NotImplementedError
 
 		return varq
+
+	def compute_pressure_gradient(self, Uq, grad_Uq):
+		'''
+		Compute the gradient of pressure with respect to physical space. This is
+		needed for pressure-based shock sensors.
+
+		Inputs:
+		-------
+			Uq: solution in each element evaluated at quadrature points
+			grad_Uq: gradient of solution in each element evaluted at quadrature
+				points
+
+		Outputs:
+		--------
+			array: gradient of pressure with respected to physical space
+				[ne, nq, ndims]
+		'''
+		srho = self.get_state_slice("Density")
+		srhoE = self.get_state_slice("Energy")
+		smom = self.get_momentum_slice()
+		rho = Uq[:, :, srho]
+		rhoE = Uq[:, :, srhoE]
+		mom = Uq[:, :, smom]
+		gamma = self.gamma
+
+		# Compute dp/dU
+		dpdU = np.empty_like(Uq)
+		dpdU[:, :, srho] = (.5 * (gamma - 1) * np.sum(mom**2, axis = 2,
+			keepdims=True) / rho)
+		dpdU[:, :, smom] = (1 - gamma) * mom / rho
+		dpdU[:, :, srhoE] = gamma - 1
+
+		# Multiply with dU/dx
+		return np.einsum('ijk, ijkl -> ijl', dpdU, grad_Uq)
 
 
 class Euler1D(Euler):
@@ -164,7 +198,7 @@ class Euler1D(Euler):
 			euler_fcn_type.MovingShock : euler_fcns.MovingShock,
 			euler_fcn_type.DensityWave : euler_fcns.DensityWave,
 			euler_fcn_type.RiemannProblem : euler_fcns.RiemannProblem,
-			euler_fcn_type.ShuOsherProblem : 
+			euler_fcn_type.ShuOsherProblem :
 					euler_fcns.ShuOsherProblem,
 		}
 
@@ -235,13 +269,13 @@ class Euler1D(Euler):
 
 	def get_conv_eigenvectors(self, U_bar):
 		'''
-		This function defines the convective eigenvectors for the 
-		1D euler equations. This is used with the WENO limiter to 
+		This function defines the convective eigenvectors for the
+		1D euler equations. This is used with the WENO limiter to
 		transform the system of equations from physical space to
 		characteristic space.
 
 		Inputs:
-		------- 
+		-------
 			U_bar: Average state [ne, 1, ns]
 
 		Outputs:
@@ -252,15 +286,15 @@ class Euler1D(Euler):
 
 		# Unpack
 		ne = U_bar.shape[0]
-		
+
 		ns = self.NUM_STATE_VARS
-		
+
 		irho, irhou, irhoE = self.get_state_indices()
 
 		rho = U_bar[:, :, irho]
 		rhou = U_bar[:, :, irhou]
 		rhoE = U_bar[:, :, irhoE]
-		
+
 		# Get velocity
 		u = rhou / rho
 		# Get squared velocity

--- a/src/physics/euler/euler.py
+++ b/src/physics/euler/euler.py
@@ -151,8 +151,9 @@ class Euler(base.PhysicsBase):
 		Inputs:
 		-------
 			Uq: solution in each element evaluated at quadrature points
+			[ne, nq, ns]
 			grad_Uq: gradient of solution in each element evaluted at quadrature
-				points
+				points [ne, nq, ns, ndims]
 
 		Outputs:
 		--------

--- a/src/solver/DG.py
+++ b/src/solver/DG.py
@@ -676,10 +676,10 @@ class DG(base.SolverBase):
 					elem_helpers, Sq) # [ne, nb, ns]
 
 		# Add artificial viscosity term
-		epsilon = -1e-2
-		artificial_viscosity = epsilon * np.einsum('ipk, ipn -> ink', Uc,
-				elem_helpers.SM_elems)
-		res_elem += artificial_viscosity
+		if self.params["ArtificialViscosity"]:
+			epsilon = self.params["AVParameter"]
+			artificial_viscosity = epsilon * elem_helpers.SM_elems @ Uc
+			res_elem -= artificial_viscosity
 
 		return res_elem # [ne, nb, ns]
 

--- a/src/solver/DG.py
+++ b/src/solver/DG.py
@@ -661,7 +661,6 @@ class DG(base.SolverBase):
 		elem_helpers = self.elem_helpers
 		basis_val = elem_helpers.basis_val
 		quad_wts = elem_helpers.quad_wts
-		djac_elems = elem_helpers.djac_elems
 
 		x_elems = elem_helpers.x_elems
 		nq = quad_wts.shape[0]
@@ -690,12 +689,6 @@ class DG(base.SolverBase):
 
 			res_elem += solver_tools.calculate_source_term_integral(
 					elem_helpers, Sq) # [ne, nb, ns]
-
-		# Add artificial viscosity term
-		if self.params["ArtificialViscosity"]:
-			res_elem -= solver_tools.calculate_artificial_viscosity_integral(
-					physics, elem_helpers, Uc, self.params["AVParameter"],
-					self.order)
 
 		return res_elem # [ne, nb, ns]
 

--- a/src/solver/DG.py
+++ b/src/solver/DG.py
@@ -66,6 +66,8 @@ class ElemHelpers(object):
 		stores the stiffness matrix for each element
 	vol_elems: numpy array
 		stores the volume of each element
+	normals_elems: numpy array
+		stores the normals of each face of each element
 	domain_vol: float
 		stores the total volume of the domain
 
@@ -99,13 +101,14 @@ class ElemHelpers(object):
 		self.iMM_elems = np.zeros(0)
 		self.SM_elems = np.zeros(0)
 		self.vol_elems = np.zeros(0)
+		self.normals_elems = np.zeros(0)
 		self.domain_vol = 0.
 		self.need_phys_grad = True
 
 	def get_gaussian_quadrature(self, mesh, physics, basis, order):
 		'''
 		Precomputes the quadrature points and weights given the computed
-		quadrature order
+		quadrature order. Also computes them for the faces of each element.
 
 		Inputs:
 		-------
@@ -118,11 +121,15 @@ class ElemHelpers(object):
 		--------
 			self.quad_pts: precomputed quadrature points [nq, ndims]
 			self.quad_wts: precomputed quadrature weights [nq, 1]
+			self.face_quad_pts: precomputed quadrature points at faces [nqf, ndims]
 		'''
 		gbasis = mesh.gbasis
 		quad_order = gbasis.get_quadrature_order(mesh, order,
 				physics=physics)
 		self.quad_pts, self.quad_wts = basis.get_quadrature_data(quad_order)
+		face_quad_order = gbasis.FACE_SHAPE.get_quadrature_order(mesh,
+			order, physics=physics)
+		self.face_quad_pts, self.face_quad_wts = basis.FACE_SHAPE.get_quadrature_data(quad_order)
 
 	def get_basis_and_geom_data(self, mesh, basis, order):
 		'''
@@ -162,6 +169,8 @@ class ElemHelpers(object):
 		self.djac_elems = np.zeros([num_elems, nq, 1])
 		self.x_elems = np.zeros([num_elems, nq, ndims])
 		self.basis_phys_grad_elems = np.zeros([num_elems, nq, nb, ndims])
+		self.normals_elems = np.empty([num_elems, mesh.gbasis.NFACES,
+			self.face_quad_pts.shape[0], ndims])
 
 		# Basis data
 		basis.get_basis_val_grads(self.quad_pts, get_val=True,
@@ -191,8 +200,14 @@ class ElemHelpers(object):
 				self.basis_phys_grad_elems[elem_ID] = basis.basis_phys_grad
 					# [nq, nb, ndims]
 
+			# Face normals
+			for i in range(mesh.gbasis.NFACES):
+				self.normals_elems[elem_ID, i] = mesh.gbasis.calculate_normals(
+						mesh, elem_ID, i, self.face_quad_pts)
+
 		# Volumes
 		self.vol_elems, self.domain_vol = mesh_tools.element_volumes(mesh)
+
 
 	def alloc_other_arrays(self, physics, basis, order):
 		'''
@@ -679,7 +694,7 @@ class DG(base.SolverBase):
 		# Add artificial viscosity term
 		if self.params["ArtificialViscosity"]:
 			res_elem -= solver_tools.calculate_artificial_viscosity_integral(
-					physics, Uc, elem_helpers, self.params["AVParameter"],
+					physics, elem_helpers, Uc, self.params["AVParameter"],
 					self.order)
 
 		return res_elem # [ne, nb, ns]

--- a/src/solver/DG.py
+++ b/src/solver/DG.py
@@ -690,6 +690,12 @@ class DG(base.SolverBase):
 			res_elem += solver_tools.calculate_source_term_integral(
 					elem_helpers, Sq) # [ne, nb, ns]
 
+		# Add artificial viscosity term
+		if self.params["ArtificialViscosity"]:
+			res_elem -= solver_tools.calculate_artificial_viscosity_integral(
+					physics, elem_helpers, Uc, self.params["AVParameter"],
+					self.order)
+
 		return res_elem # [ne, nb, ns]
 
 	def get_interior_face_residual(self, faceL_IDs, faceR_IDs, UcL, UcR):

--- a/src/solver/DG.py
+++ b/src/solver/DG.py
@@ -62,8 +62,6 @@ class ElemHelpers(object):
 		source vector evaluated at the quadrature points
 	iMM_elems: numpy array
 		stores the inverse mass matrix for each element
-	SM_elems: numpy array
-		stores the stiffness matrix for each element
 	vol_elems: numpy array
 		stores the volume of each element
 	normals_elems: numpy array
@@ -99,7 +97,6 @@ class ElemHelpers(object):
 		self.Fq = np.zeros(0)
 		self.Sq = np.zeros(0)
 		self.iMM_elems = np.zeros(0)
-		self.SM_elems = np.zeros(0)
 		self.vol_elems = np.zeros(0)
 		self.normals_elems = np.zeros(0)
 		self.domain_vol = 0.
@@ -246,16 +243,12 @@ class ElemHelpers(object):
 		--------
 			self.iMM_elems: precomputed inverse mass matrix for each element
 				[mesh.num_elems, nb, nb]
-			self.SM_elems: precomputed stiffness matrix for each element
-				[mesh.num_elems, nb, nb]
 		'''
 		self.get_gaussian_quadrature(mesh, physics, basis, order)
 		self.get_basis_and_geom_data(mesh, basis, order)
 		self.alloc_other_arrays(physics, basis, order)
 		self.iMM_elems = basis_tools.get_inv_mass_matrices(mesh,
 				basis, order)
-		self.SM_elems = basis_tools.get_poisson_stiffness_matrices(
-				self.basis_phys_grad_elems, self.quad_wts, self.djac_elems)
 
 
 class InteriorFaceHelpers(ElemHelpers):
@@ -692,9 +685,9 @@ class DG(base.SolverBase):
 
 		# Add artificial viscosity term
 		if self.params["ArtificialViscosity"]:
+			av_param = self.params["AVParameter"]
 			res_elem -= solver_tools.calculate_artificial_viscosity_integral(
-					physics, elem_helpers, Uc, self.params["AVParameter"],
-					self.order)
+					physics, elem_helpers, Uc, av_param, self.order)
 
 		return res_elem # [ne, nb, ns]
 

--- a/src/solver/DG.py
+++ b/src/solver/DG.py
@@ -646,6 +646,7 @@ class DG(base.SolverBase):
 		elem_helpers = self.elem_helpers
 		basis_val = elem_helpers.basis_val
 		quad_wts = elem_helpers.quad_wts
+		djac_elems = elem_helpers.djac_elems
 
 		x_elems = elem_helpers.x_elems
 		nq = quad_wts.shape[0]
@@ -677,9 +678,9 @@ class DG(base.SolverBase):
 
 		# Add artificial viscosity term
 		if self.params["ArtificialViscosity"]:
-			epsilon = self.params["AVParameter"]
-			artificial_viscosity = epsilon * elem_helpers.SM_elems @ Uc
-			res_elem -= artificial_viscosity
+			res_elem -= solver_tools.calculate_artificial_viscosity_integral(
+					physics, Uc, elem_helpers, self.params["AVParameter"],
+					self.order)
 
 		return res_elem # [ne, nb, ns]
 

--- a/src/solver/base.py
+++ b/src/solver/base.py
@@ -440,12 +440,6 @@ class SolverBase(ABC):
 		self.get_element_residuals(U, res)
 		self.get_interior_face_residuals(U, res)
 
-		# Add artificial viscosity term
-		if self.params["ArtificialViscosity"]:
-			res -= solver_tools.calculate_artificial_viscosity_integral(
-					physics, self.elem_helpers, U, res, self.params["AVParameter"],
-					self.order)
-
 		return res
 
 	def get_element_residuals(self, U, res):

--- a/src/solver/base.py
+++ b/src/solver/base.py
@@ -440,6 +440,12 @@ class SolverBase(ABC):
 		self.get_element_residuals(U, res)
 		self.get_interior_face_residuals(U, res)
 
+		# Add artificial viscosity term
+		if self.params["ArtificialViscosity"]:
+			res -= solver_tools.calculate_artificial_viscosity_integral(
+					physics, self.elem_helpers, U, res, self.params["AVParameter"],
+					self.order)
+
 		return res
 
 	def get_element_residuals(self, U, res):


### PR DESCRIPTION
This branch adds the artificial viscosity model of Hartmann into the volume residual term, to be used for resolving and stabilizing strong shocks. To use, a Numerics flag, "ArtificialViscosity", should be set to True in the input file, along with a value of "AVParameter". In testing, it was found that for normalized problems (sod shock tube case) this parameter was around 1e0 to 1e2. For physical cases (supersonic exterior flow in air) it could be around 1e5 to 1e7. Turning on AV sometimes requires a lower time step as well because of the viscous timescale. On certain meshes (especially anisotropic ones) sometimes this still crashes, but pairing it with the positivity preserving limiter solves this problem.