### PR TITLE
Consistent Restart File Iteration Counts and File Naming

### DIFF
--- a/src/quail
+++ b/src/quail
@@ -427,7 +427,7 @@ def driver(deck):
 			solver.stepper.dt = 0.
 			stepper_tools.set_time_stepping_approach(solver.stepper,
 					solver.params)
-			solver.stepper.num_time_steps = solver_old.stepper.num_time_steps
+			solver.stepper.num_time_steps += solver_old.stepper.num_time_steps
 
 
 	'''

--- a/src/quail
+++ b/src/quail
@@ -4,12 +4,12 @@
 #       quail: A lightweight discontinuous Galerkin code for
 #              teaching and prototyping
 #		<https://github.com/IhmeGroup/quail>
-#       
+#
 #		Copyright (C) 2020-2021
 #
 #       This program is distributed under the terms of the GNU
 #		General Public License v3.0. You should have received a copy
-#       of the GNU General Public License along with this program.  
+#       of the GNU General Public License along with this program.
 #		If not, see <https://www.gnu.org/licenses/>.
 #
 # ------------------------------------------------------------------------ #
@@ -420,12 +420,14 @@ def driver(deck):
 					solver_old.basis, solver_old.order)
 		else:
 			solver.state_coeffs = solver_old.state_coeffs
-			# Time
+		# Start from the same time and iteration count
 		if restart_params["StartFromFileTime"]:
 			solver.time = solver_old.time
+			solver.itime = solver_old.itime
 			solver.stepper.dt = 0.
 			stepper_tools.set_time_stepping_approach(solver.stepper,
 					solver.params)
+			solver.stepper.num_time_steps = solver_old.stepper.num_time_steps
 
 
 	'''

--- a/src/solver/base.py
+++ b/src/solver/base.py
@@ -3,12 +3,12 @@
 #       quail: A lightweight discontinuous Galerkin code for
 #              teaching and prototyping
 #		<https://github.com/IhmeGroup/quail>
-#       
+#
 #		Copyright (C) 2020-2021
 #
 #       This program is distributed under the terms of the GNU
 #		General Public License v3.0. You should have received a copy
-#       of the GNU General Public License along with this program.  
+#       of the GNU General Public License along with this program.
 #		If not, see <https://www.gnu.org/licenses/>.
 #
 # ------------------------------------------------------------------------ #
@@ -63,6 +63,8 @@ class SolverBase(ABC):
 		contains the geometric information for the solver's mesh
 	time: float
 		global time of the solution at the given time step
+	itime: int
+		global iteration count
 	basis: object
 		contains all the information and methods for the basis class
 	order: int
@@ -508,7 +510,7 @@ class SolverBase(ABC):
 		np.add.at(res, elemL_IDs, -RL)
 		np.add.at(res, elemR_IDs,  RR)
 
-		# Add the additional diffusion portion of the residual to the 
+		# Add the additional diffusion portion of the residual to the
 		# correct left/right states.
 		np.add.at(res, elemL_IDs,  RL_diff)
 		np.add.at(res, elemR_IDs,  RR_diff)
@@ -641,7 +643,6 @@ class SolverBase(ABC):
 			readwritedatafiles.write_data_file(self, 0)
 
 		t0 = time.time()
-		iwrite = 1
 
 		print("\n\nUNSTEADY SOLVE:")
 		print("--------------------------------------------------------" + \
@@ -650,8 +651,8 @@ class SolverBase(ABC):
 		# Custom user function initial iteration
 		self.custom_user_function(self)
 
-		itime = 0
-		while itime < stepper.num_time_steps:
+		solver.itime = 0
+		while solver.itime < stepper.num_time_steps:
 			# Reset min and max state
 			self.max_state[:] = -np.inf
 			self.min_state[:] = np.inf
@@ -670,15 +671,14 @@ class SolverBase(ABC):
 			self.custom_user_function(self)
 
 			# Print info
-			self.print_info(physics, res, itime, t, stepper.dt)
-
+			self.print_info(physics, res, solver.itime, t, stepper.dt)
 
 			# Write data file
-			if (itime + 1) % write_interval == 0:
-				readwritedatafiles.write_data_file(self, iwrite)
-				iwrite += 1
+			if (solver.itime + 1) % write_interval == 0:
+				readwritedatafiles.write_data_file(self,
+                        (solver.itime + 1) // write_interval)
 
-			itime += 1
+			solver.itime += 1
 
 		t1 = time.time()
 		print("\nWall clock time = %g seconds" % (t1 - t0))

--- a/src/solver/base.py
+++ b/src/solver/base.py
@@ -651,7 +651,6 @@ class SolverBase(ABC):
 		# Custom user function initial iteration
 		self.custom_user_function(self)
 
-		self.itime = 0
 		while self.itime < stepper.num_time_steps:
 			# Reset min and max state
 			self.max_state[:] = -np.inf

--- a/src/solver/base.py
+++ b/src/solver/base.py
@@ -652,7 +652,7 @@ class SolverBase(ABC):
 		self.custom_user_function(self)
 
 		self.itime = 0
-		while solver.itime < stepper.num_time_steps:
+		while self.itime < stepper.num_time_steps:
 			# Reset min and max state
 			self.max_state[:] = -np.inf
 			self.min_state[:] = np.inf
@@ -671,12 +671,12 @@ class SolverBase(ABC):
 			self.custom_user_function(self)
 
 			# Print info
-			self.print_info(physics, res, solver.itime, t, stepper.dt)
+			self.print_info(physics, res, self.itime, t, stepper.dt)
 
 			# Write data file
-			if (solver.itime + 1) % write_interval == 0:
+			if (self.itime + 1) % write_interval == 0:
 				readwritedatafiles.write_data_file(self,
-						(solver.itime + 1) // write_interval)
+						(self.itime + 1) // write_interval)
 
 			self.itime += 1
 

--- a/src/solver/base.py
+++ b/src/solver/base.py
@@ -124,6 +124,7 @@ class SolverBase(ABC):
 		self.mesh = mesh
 
 		self.time = params["InitialTime"]
+		self.itime = 0
 
 		# Set solution basis and order
 		self.order = params["SolutionOrder"]

--- a/src/solver/base.py
+++ b/src/solver/base.py
@@ -651,7 +651,7 @@ class SolverBase(ABC):
 		# Custom user function initial iteration
 		self.custom_user_function(self)
 
-		solver.itime = 0
+		self.itime = 0
 		while solver.itime < stepper.num_time_steps:
 			# Reset min and max state
 			self.max_state[:] = -np.inf
@@ -678,7 +678,7 @@ class SolverBase(ABC):
 				readwritedatafiles.write_data_file(self,
 						(solver.itime + 1) // write_interval)
 
-			solver.itime += 1
+			self.itime += 1
 
 		t1 = time.time()
 		print("\nWall clock time = %g seconds" % (t1 - t0))

--- a/src/solver/base.py
+++ b/src/solver/base.py
@@ -676,7 +676,7 @@ class SolverBase(ABC):
 			# Write data file
 			if (solver.itime + 1) % write_interval == 0:
 				readwritedatafiles.write_data_file(self,
-                        (solver.itime + 1) // write_interval)
+						(solver.itime + 1) // write_interval)
 
 			solver.itime += 1
 


### PR DESCRIPTION
In the main branch of Quail, when a case is run for a set number of iterations, stopped, then restarted, the data files and iteration counter restart from 0. The issue with this is that across multiple restarts, the Pickle files are no longer ordered sequentially in time, since the iteration resets to zero after every restart, thus making it very hard to track the restarts and also to make animations of unsteady cases. There is a "StartFromFileTime" option in the restart inputs, however this only fixes the solution time during a restart, not the iteration count or the numbering given to the Pickle files. This PR addresses this issue. When the "StartFromFileTime" option is enabled, not only is the solution time kept consistent across the restart, but the iteration count and the file naming is as well.