### PR TITLE
Bug/physics object dependency

### DIFF
--- a/src/physics/base/base.py
+++ b/src/physics/base/base.py
@@ -209,7 +209,7 @@ class PhysicsBase(ABC):
 		'''
 		pass
 
-	def __init__(self, mesh):
+	def __init__(self):
 		'''
 		This method initializes the attributes (see above for attribute
 		details).
@@ -233,14 +233,10 @@ class PhysicsBase(ABC):
 		self.diff_num_flux_map = {}
 		self.IC = None
 		self.exact_soln = None
-		self.BCs = dict.fromkeys(mesh.boundary_groups.keys())
+		self.BCs = {}
 		self.source_terms = []
 		self.conv_flux_fcn = None
 		self.diff_flux_fcn = None
-
-		# Compatibility check
-		if mesh.ndims != self.NDIMS:
-			raise errors.IncompatibleError
 
 		# Set indices and slices corresponding to the state variables
 		set_state_indices_slices(self)

--- a/src/physics/euler/euler.py
+++ b/src/physics/euler/euler.py
@@ -60,8 +60,8 @@ class Euler(base.PhysicsBase):
 	'''
 	PHYSICS_TYPE = general.PhysicsType.Euler
 
-	def __init__(self, mesh):
-		super().__init__(mesh)
+	def __init__(self):
+		super().__init__()
 		self.R = 0.
 		self.gamma = 0.
 
@@ -377,8 +377,8 @@ class Euler2D(Euler):
 	NUM_STATE_VARS = 4
 	NDIMS = 2
 
-	def __init__(self, mesh):
-		super().__init__(mesh)
+	def __init__(self):
+		super().__init__()
 
 	def set_maps(self):
 		super().set_maps()

--- a/src/physics/navierstokes/navierstokes.py
+++ b/src/physics/navierstokes/navierstokes.py
@@ -66,8 +66,8 @@ class NavierStokes(euler.Euler):
 	'''
 	PHYSICS_TYPE = general.PhysicsType.NavierStokes
 
-	def __init__(self, mesh):
-		super().__init__(mesh)
+	def __init__(self):
+		super().__init__()
 		self.R = 0.
 		self.gamma = 0.
 
@@ -192,8 +192,8 @@ class NavierStokes2D(NavierStokes, euler.Euler2D):
 	NUM_STATE_VARS = 4
 	NDIMS = 2
 
-	def __init__(self, mesh):
-		super().__init__(mesh)
+	def __init__(self):
+		super().__init__()
 
 	def set_maps(self):
 		super().set_maps()

--- a/src/physics/scalar/scalar.py
+++ b/src/physics/scalar/scalar.py
@@ -63,8 +63,8 @@ class ConstAdvScalar(base.PhysicsBase):
 	NUM_STATE_VARS = 1
 	PHYSICS_TYPE = general.PhysicsType.ConstAdvScalar
 
-	def __init__(self, mesh):
-		super().__init__(mesh)
+	def __init__(self):
+		super().__init__()
 		self.c = 0.
 		self.cspeed = 0.
 
@@ -154,8 +154,8 @@ class ConstAdvScalar2D(ConstAdvScalar):
 	'''
 	NDIMS = 2
 
-	def __init__(self, mesh):
-		super().__init__(mesh)
+	def __init__(self):
+		super().__init__()
 		self.c = np.zeros(2)
 		self.cspeed = 0.
 
@@ -224,8 +224,8 @@ class ConstAdvDiffScalar(base.PhysicsBase):
 	NUM_STATE_VARS = 1
 	PHYSICS_TYPE = general.PhysicsType.ConstAdvDiffScalar
 
-	def __init__(self, mesh):
-		super().__init__(mesh)
+	def __init__(self):
+		super().__init__()
 		self.c = 0.
 		self.cspeed = 0.
 
@@ -321,8 +321,8 @@ class ConstAdvDiffScalar2D(ConstAdvDiffScalar):
 	'''
 	NDIMS = 2
 
-	def __init__(self, mesh):
-		super().__init__(mesh)
+	def __init__(self):
+		super().__init__()
 		self.c = np.zeros(2)
 		self.cspeed = 0.
 		self.al = np.zeros(2)

--- a/src/quail
+++ b/src/quail
@@ -103,7 +103,7 @@ def set_physics(mesh, physics_type):
 	else:
 	    raise NotImplementedError
 
-	physics = physics_class(mesh)
+	physics = physics_class()
 
 	return physics
 
@@ -372,6 +372,8 @@ def driver(deck):
 		physics.set_exact(exact_type=exact_type, **eparams)
 
 	# Boundary conditions
+	physics.BCs = dict.fromkeys(mesh.boundary_groups.keys())
+
 	for bname, bparams in BC_params.items():
 		bparams = bparams.copy()
 		BC_type = bparams.pop("BCType")
@@ -389,7 +391,6 @@ def driver(deck):
 		sparams.pop("Function")
 		physics.set_source(source_type=sname, **sparams)
 
-
 	'''
 	Solver
 	'''
@@ -403,7 +404,6 @@ def driver(deck):
 		solver = ADERDG.ADERDG(solver_params, physics, mesh)
 	else:
 		raise NotImplementedError
-
 
 	'''
 	Restart file

--- a/test/component/numerics/limiting/test_limiting.py
+++ b/test/component/numerics/limiting/test_limiting.py
@@ -31,7 +31,7 @@ def create_solver_object():
 			SolutionBasis="LagrangeSeg",
 			ApplyLimiters=["PositivityPreserving"])
 
-	physics = euler.Euler1D(mesh)
+	physics = euler.Euler1D()
 	physics.set_conv_num_flux("Roe")
 	physics.set_physical_params()
 	U = np.array([1., 0., 1.])

--- a/test/component/numerics/timestepping/test_stepper_tools.py
+++ b/test/component/numerics/timestepping/test_stepper_tools.py
@@ -25,7 +25,7 @@ def create_solver_object():
 	params = general.set_solver_params(SolutionOrder=1, 
 			FinalTime=10.0, NumTimeSteps=1000, ApplyLimiters=[])
 	
-	physics = scalar.ConstAdvScalar1D(mesh)
+	physics = scalar.ConstAdvScalar1D()
 	physics.set_conv_num_flux("LaxFriedrichs")
 	physics.set_physical_params()
 	U = np.array([1.])

--- a/test/component/physics/euler/test_euler.py
+++ b/test/component/physics/euler/test_euler.py
@@ -4,7 +4,6 @@ import sys
 sys.path.append('../src')
 
 import physics.euler.euler as euler
-import meshing.meshbase as meshbase
 
 rtol = 1e-15
 atol = 1e-15
@@ -14,8 +13,7 @@ def test_convective_flux_1D():
 	'''
 	This tests the convective flux for a 1D case.
 	'''
-	mesh = meshbase.Mesh()
-	physics = euler.Euler1D(mesh)
+	physics = euler.Euler1D()
 
 	ns = physics.NUM_STATE_VARS
 
@@ -52,8 +50,7 @@ def test_convective_flux_1D_zero_velocity():
 	'''
 	This tests the convective flux for a 1D case but with zero vel
 	'''
-	mesh = meshbase.Mesh()
-	physics = euler.Euler1D(mesh)
+	physics = euler.Euler1D()
 
 	ns = physics.NUM_STATE_VARS
 
@@ -89,8 +86,7 @@ def test_convective_flux_2D():
 	'''
 	This tests the convective flux for a 2D case.
 	'''
-	mesh = meshbase.Mesh(ndims=2)
-	physics = euler.Euler2D(mesh)
+	physics = euler.Euler2D()
 
 	ns = physics.NUM_STATE_VARS
 
@@ -135,8 +131,7 @@ def test_convective_flux_2D_zero_velocity():
 	'''
 	This tests the convective flux for a 2D case with zero vel
 	'''
-	mesh = meshbase.Mesh(ndims=2)
-	physics = euler.Euler2D(mesh)
+	physics = euler.Euler2D()
 
 	ns = physics.NUM_STATE_VARS
 
@@ -180,8 +175,7 @@ def test_conv_eigenvectors_multiplied_is_identity():
 	This tests the convective eigenvectors in euler and ensures
 	that when dotted together they are identity
 	'''
-	mesh = meshbase.Mesh(ndims=1)
-	physics = euler.Euler1D(mesh)
+	physics = euler.Euler1D()
 	ns = physics.NUM_STATE_VARS
 	irho, irhou, irhoE = physics.get_state_indices()
 	physics.set_physical_params()

--- a/test/component/physics/euler/test_functions.py
+++ b/test/component/physics/euler/test_functions.py
@@ -4,7 +4,6 @@ import sys
 sys.path.append('../src')
 
 import physics.euler.euler as euler
-import meshing.meshbase as meshbase
 
 rtol = 1e-15
 atol = 1e-15
@@ -19,8 +18,7 @@ def test_numerical_flux_1D_consistency(conv_num_flux_type):
 	This test ensures that the 1D numerical flux functions are 
 	consistent, .e. F_numerical(u, u, n) = F(u) dot n
 	'''
-	mesh = meshbase.Mesh()
-	physics = euler.Euler1D(mesh)
+	physics = euler.Euler1D()
 	physics.set_conv_num_flux(conv_num_flux_type)
 	physics.set_physical_params()
 
@@ -42,7 +40,7 @@ def test_numerical_flux_1D_consistency(conv_num_flux_type):
 	UqR = UqL.copy()
 
 	# Normals
-	normals = np.zeros([1, 1, mesh.ndims])
+	normals = np.zeros([1, 1, 1])
 	normals[:, :, 0] = 0.5
 
 	# Compute numerical flux
@@ -64,8 +62,7 @@ def test_numerical_flux_1D_conservation(conv_num_flux_type):
 	conservative, i.e. 
 	F_numerical(uL, uR, n) = -F_numerical(uR, uL, -n)
 	'''
-	mesh = meshbase.Mesh()
-	physics = euler.Euler1D(mesh)
+	physics = euler.Euler1D()
 	physics.set_conv_num_flux(conv_num_flux_type)
 	physics.set_physical_params()
 
@@ -96,7 +93,7 @@ def test_numerical_flux_1D_conservation(conv_num_flux_type):
 	UqR[:, :, irhoE] = rhoE
 
 	# Normals
-	normals = np.zeros([1, 1, mesh.ndims])
+	normals = np.zeros([1, 1, 1])
 	normals[:, :, 0] = 0.5
 
 	# Compute numerical flux
@@ -119,8 +116,7 @@ def test_numerical_flux_2D_consistency(conv_num_flux_type):
 	This test ensures that the 2D numerical flux functions are 
 	consistent, .e. F_numerical(u, u, n) = F(u) dot n
 	'''
-	mesh = meshbase.Mesh(ndims=2)
-	physics = euler.Euler2D(mesh)
+	physics = euler.Euler2D()
 	physics.set_conv_num_flux(conv_num_flux_type)
 	physics.set_physical_params()
 
@@ -144,7 +140,7 @@ def test_numerical_flux_2D_consistency(conv_num_flux_type):
 	UqR = UqL.copy()
 
 	# Normals
-	normals = np.zeros([1, 1, mesh.ndims])
+	normals = np.zeros([1, 1, 2])
 	normals[:, :, 0] = -0.4
 	normals[:, :, 1] = 0.7
 
@@ -167,8 +163,7 @@ def test_numerical_flux_2D_conservation(conv_num_flux_type):
 	conservative, i.e. 
 	F_numerical(uL, uR, n) = -F_numerical(uR, uL, -n)
 	'''
-	mesh = meshbase.Mesh(ndims=2)
-	physics = euler.Euler2D(mesh)
+	physics = euler.Euler2D()
 	physics.set_conv_num_flux(conv_num_flux_type)
 	physics.set_physical_params()
 
@@ -203,7 +198,7 @@ def test_numerical_flux_2D_conservation(conv_num_flux_type):
 	UqR[:, :, irhoE] = rhoE
 
 	# Normals
-	normals = np.zeros([1, 1, mesh.ndims])
+	normals = np.zeros([1, 1, 2])
 	normals[:, :, 0] = -0.4
 	normals[:, :, 1] = 0.7
 

--- a/test/component/physics/navierstokes/test_navierstokes.py
+++ b/test/component/physics/navierstokes/test_navierstokes.py
@@ -5,7 +5,6 @@ sys.path.append('../src')
 
 import physics.navierstokes.navierstokes as navierstokes
 import physics.navierstokes.tools as ns_tools
-import meshing.meshbase as meshbase
 
 rtol = 1e-15
 atol = 1e-15
@@ -15,8 +14,7 @@ def test_diffusion_flux_2D():
 	'''
 	This tests the diffusive flux for a 2D case.
 	'''
-	mesh = meshbase.Mesh(ndims=2)
-	physics = navierstokes.NavierStokes2D(mesh)
+	physics = navierstokes.NavierStokes2D()
 	physics.set_physical_params()
 	physics.get_transport = ns_tools.set_transport("Sutherland")
 
@@ -62,7 +60,7 @@ def test_diffusion_flux_2D():
 	tauxy = mu * (dudy + dvdx)
 	tauyy = mu * (dvdy + dvdy - 2. / 3. * divu)
 
-	gUq = np.zeros([1, 1, ns, mesh.ndims])
+	gUq = np.zeros([1, 1, ns, 2])
 
 	gUq[:, :, irho, 0] = drdx
 	gUq[:, :, irhou, 0] = drdx * u + rho * dudx
@@ -97,8 +95,7 @@ def test_diffusion_flux_2D_zero_velocity():
 	'''
 	This tests the diffusive flux for a 2D case with zero vel
 	'''
-	mesh = meshbase.Mesh(ndims=2)
-	physics = navierstokes.NavierStokes2D(mesh)
+	physics = navierstokes.NavierStokes2D()
 	physics.set_physical_params()
 	physics.get_transport = ns_tools.set_transport("Sutherland")
 
@@ -138,7 +135,7 @@ def test_diffusion_flux_2D_zero_velocity():
 	dTdx = np.random.rand()
 	dTdy = np.random.rand()
 
-	gUq = np.zeros([1, 1, ns, mesh.ndims])
+	gUq = np.zeros([1, 1, ns, 2])
 	gUq[:, :, irho, 0] = drdx
 	gUq[:, :, irhoE, 0] = (R * T / (gamma - 1.)) * drdx \
 		+ rho * R / (gamma - 1.) * dTdx


### PR DESCRIPTION
To instantiate the physics object, a mesh object was also needed. This is not ideal as we would like mesh and physics to be separate. To this end, this pull request removes any dependencies of mesh for the physics class. The main difference is the initialization of the physics.BCs dictionary. This has been moved to the `quail` file in the `driver` function. This pull request should result in closing https://github.com/IhmeGroup/quail/issues/19#issue-965209819