### PR TITLE
Fix compatibility with matplotlib  3.5.1 (2D animation issue)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@
 Quail is a lightweight, open-source discontinuous Galerkin code written in Python for teaching and prototyping. Currently, Quail solves first-order and second-order nonlinear systems of partial differential equations.
 
 ### Setup
-Python 3.7 or higher is required. The following libraries should also be installed (tested version number provided):
-  - NumPy 1.17.4
-  - Matplotlib 3.3.1
-  - SciPy 1.4.1
+Python 3.7 or higher is required. The following libraries should also be installed (tested version numbers provided):
+  - NumPy 1.17.4, 1.22.3
+  - Matplotlib 3.3.1, 3.5.1
+  - SciPy 1.4.1, 1.7.3
   - LaTeX (used for post-processing)
 
 Optional libraries:

--- a/examples/scalar/2D/constant_advection/create_anim.py
+++ b/examples/scalar/2D/constant_advection/create_anim.py
@@ -32,7 +32,7 @@ for i in range(101):
 	plot.plot_solution(mesh, physics, solver, "Scalar", plot_numerical=True, create_new_figure=False, 
 			include_mesh=True, regular_2D=True, equal_AR=False, show_elem_IDs=True, ignore_colorbar=ignore_colorbar)
 
-	imgs = ax.collections.copy()
+	imgs = ax.collections
 
 	# Add to imgs_all
 	if j == 0:

--- a/examples/scalar/2D/constant_advection_diffusion/create_anim.py
+++ b/examples/scalar/2D/constant_advection_diffusion/create_anim.py
@@ -36,7 +36,7 @@ for i in range(33):
 			include_mesh=True, regular_2D=True, equal_AR=False, show_elem_IDs=False, ignore_colorbar=ignore_colorbar,
 			levels=levels)
 
-	imgs = ax.collections.copy()
+	imgs = ax.collections
 
 	# Add to imgs_all
 	if j == 0:


### PR DESCRIPTION
This pull request closes #40 by removing the `*.copy()` for the `collections` command in the `create_anim.py` post-processing files. This has been tested for matplotlib version 3.3.1 and the behavior is identical.

